### PR TITLE
Refine zoom behavior on map

### DIFF
--- a/src/app/helpers/drag-handler.ts
+++ b/src/app/helpers/drag-handler.ts
@@ -11,9 +11,9 @@ import { resetContainerPositions } from './pixi-app-setup';
 export interface DragHandlerConfig {
   app: Application;
   containers: Container[];
-  viewportWidth: number;
-  viewportHeight: number;
-  tileSize?: number;
+  viewportWidth: () => number;
+  viewportHeight: () => number;
+  tileSize?: () => number;
 }
 
 /**
@@ -27,7 +27,7 @@ export function setupMapDragging(config: DragHandlerConfig): DragState {
     containers,
     viewportWidth,
     viewportHeight,
-    tileSize = 64,
+    tileSize = () => 64,
   } = config;
 
   const dragState: DragState = {
@@ -61,15 +61,15 @@ export function setupMapDragging(config: DragHandlerConfig): DragState {
     const bounds = calculateCameraBounds(
       world.width,
       world.height,
-      viewportWidth,
-      viewportHeight,
+      viewportWidth(),
+      viewportHeight(),
     );
 
     const result = processCameraDrag(
       dragState.accumulatedDrag,
       currentCamera,
       bounds,
-      tileSize,
+      tileSize(),
     );
 
     updateCameraPosition(result.newCamera);


### PR DESCRIPTION
## Summary
- use a reactive zoomLevel signal and compute visible tiles based on the zoom
- update drag handler to accept getters for viewport size and tile size
- recalc map bounds and camera when zooming

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f0aea88832fa024bf7fe4d5d98d